### PR TITLE
fix URL to CSA format spec page

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 //! assert_eq!(csa_str, g.to_string());
 //! ```
 //!
-//! [CSA]: http://www.computer-shogi.org/protocol/record_v22.html
+//! [CSA]: http://www2.computer-shogi.org/protocol/record_v22.html
 
 pub mod parser;
 pub mod value;


### PR DESCRIPTION
It seems that the CSA spec page has moved.

Detected by [cargo-deadlinks](https://crates.io/crates/cargo-deadlinks):

```console
$ cargo deadlinks --check-http
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
Found invalid urls in index.html:
	Error fetching http://www.computer-shogi.org/protocol/record_v22.html: Dns Failed: failed to lookup address information: nodename nor servname provided, or not known
```