### PR TITLE
retire chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/nozaq/csa-rs"
 documentation = "http://nozaq.github.io/csa-rs"
 readme = "README.md"
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 time = { version = "0.3.5", features = ["formatting", "std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-chrono = "0.4"
+time = { version = "0.3.5", features = ["formatting", "std"] }
 nom = "6"
 
 [badges]

--- a/src/parser/game.rs
+++ b/src/parser/game.rs
@@ -325,7 +325,7 @@ pub fn game_record(input: &[u8]) -> IResult<&[u8], GameRecord> {
 mod tests {
     use super::*;
 
-    use chrono::{NaiveDate, NaiveTime};
+    use time::{Date as NativeDate, Time as NativeTime};
 
     #[test]
     fn parse_comment() {
@@ -421,8 +421,9 @@ mod tests {
                 (
                     "START_TIME".to_string(),
                     GameAttribute::Time(Time {
-                        date: NaiveDate::from_ymd(2002, 1, 1),
-                        time: Some(NaiveTime::from_hms(19, 0, 0))
+                        date: NativeDate::from_calendar_date(2002, time::Month::January, 1)
+                            .unwrap(),
+                        time: Some(NativeTime::from_hms(19, 0, 0).unwrap())
                     })
                 )
             ))
@@ -805,12 +806,12 @@ T6
                     event: Some("13th World Computer Shogi Championship".to_string()),
                     site: Some("KAZUSA ARC".to_string()),
                     start_time: Some(Time {
-                        date: NaiveDate::from_ymd(2003, 5, 3),
-                        time: Some(NaiveTime::from_hms(10, 30, 0))
+                        date: NativeDate::from_calendar_date(2003, time::Month::May, 3).unwrap(),
+                        time: Some(NativeTime::from_hms(10, 30, 0).unwrap())
                     }),
                     end_time: Some(Time {
-                        date: NaiveDate::from_ymd(2003, 5, 3),
-                        time: Some(NaiveTime::from_hms(11, 11, 5))
+                        date: NativeDate::from_calendar_date(2003, time::Month::May, 3).unwrap(),
+                        time: Some(NativeTime::from_hms(11, 11, 5).unwrap())
                     }),
                     time_limit: Some(TimeLimit {
                         main_time: Duration::from_secs(1500),

--- a/src/parser/game.rs
+++ b/src/parser/game.rs
@@ -131,7 +131,7 @@ fn white_player(input: &[u8]) -> IResult<&[u8], &[u8]> {
 }
 
 fn game_text_attr(input: &[u8]) -> IResult<&[u8], GameAttribute> {
-    map(map_res(not_line_sep, |s| str::from_utf8(s)), |s: &str| {
+    map(map_res(not_line_sep, str::from_utf8), |s: &str| {
         GameAttribute::Str(s.to_string())
     })(input)
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -59,7 +59,7 @@ mod tests {
                 .expect("failed to load a fixuture content");
             let res = parse_csa(&contents);
 
-            assert_eq!(res.is_ok(), true);
+            assert!(res.is_ok());
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,6 +1,6 @@
-use chrono::{NaiveDate, NaiveTime};
 use std::fmt;
 use std::time::Duration;
+use time::{Date as NativeDate, Time as NativeTime};
 
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct GameRecord {
@@ -59,15 +59,27 @@ impl fmt::Display for GameRecord {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Time {
-    pub date: NaiveDate,
-    pub time: Option<NaiveTime>,
+    pub date: NativeDate,
+    pub time: Option<NativeTime>,
 }
 
 impl fmt::Display for Time {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.date.format("%Y/%m/%d"))?;
+        write!(
+            f,
+            "{}/{:02}/{:02}",
+            self.date.year(),
+            self.date.month() as u8,
+            self.date.day()
+        )?;
         if let Some(time) = self.time {
-            write!(f, " {}", time.format("%H:%M:%S"))?;
+            write!(
+                f,
+                " {}:{:02}:{:02}",
+                time.hour(),
+                time.minute(),
+                time.second()
+            )?;
         }
 
         Ok(())
@@ -380,12 +392,12 @@ mod tests {
             event: Some("13th World Computer Shogi Championship".to_string()),
             site: Some("KAZUSA ARC".to_string()),
             start_time: Some(Time {
-                date: NaiveDate::from_ymd(2003, 5, 3),
-                time: Some(NaiveTime::from_hms(10, 30, 0)),
+                date: time::Date::from_calendar_date(2003, time::Month::May, 3).unwrap(),
+                time: Some(time::Time::from_hms(10, 30, 0).unwrap()),
             }),
             end_time: Some(Time {
-                date: NaiveDate::from_ymd(2003, 5, 3),
-                time: Some(NaiveTime::from_hms(11, 11, 5)),
+                date: time::Date::from_calendar_date(2003, time::Month::May, 3).unwrap(),
+                time: Some(time::Time::from_hms(11, 11, 5).unwrap()),
             }),
             time_limit: Some(TimeLimit {
                 main_time: Duration::from_secs(1500),

--- a/src/value.rs
+++ b/src/value.rs
@@ -58,9 +58,21 @@ impl fmt::Display for GameRecord {
 ////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+
 pub struct Time {
     pub date: NativeDate,
     pub time: Option<NativeTime>,
+}
+
+impl Time {
+    pub fn now() -> Self {
+        let now = time::OffsetDateTime::now_utc();
+
+        Time {
+            date: now.date(),
+            time: Some(now.time()),
+        }
+    }
 }
 
 impl fmt::Display for Time {


### PR DESCRIPTION
- feat: use `time` instead of `chrono`
- refactor: fix clippy warnings

fixes #14 
fixes #15 